### PR TITLE
Update docker setup to use workshop files correctly

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,14 +27,14 @@ services:
     # Networking and IPC for ROS 2
     network_mode: host
     ipc: host
-    # Allows graphical programs in the container.
+    # Allows graphical programs in the container
     environment:
       - DISPLAY=${DISPLAY}
       - QT_X11_NO_MITSHM=1
       - NVIDIA_DRIVER_CAPABILITIES=all
     volumes:
       # Mount the workshop source code
-      - ./src:/delib_ws/src/workshop_files:rw
-      # Allows graphical programs in the container.
+      - ./:/delib_ws/src/workshop_files:rw
+      # Allows graphical programs in the container
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
       - ${XAUTHORITY:-$HOME/.Xauthority}:/root/.Xauthority

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,19 +14,13 @@ RUN apt-get install -y \
 # Create a ROS 2 workspace
 RUN mkdir -p /delib_ws/src/
 
-# Install pyrobosim
-# TODO: Should we clone it this way, or include it as a submodule in the repo?
+# Install pyrobosim and its dependencies
 WORKDIR /delib_ws/src
 RUN git clone -b main https://github.com/sea-bass/pyrobosim.git
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 RUN cd pyrobosim && \
     pip3 install -e ./pyrobosim && \
     pip3 install -r test/python_test_requirements.txt
-
-# Build the ROS workspace
-WORKDIR /delib_ws
-RUN . /opt/ros/jazzy/setup.bash && \
-    colcon build
 
 # Remove MatPlotLib display warnings
 RUN mkdir /tmp/runtime-root
@@ -35,6 +29,7 @@ RUN chmod -R 0700 /tmp/runtime-root
 ENV NO_AT_BRIDGE 1
 
 # Set up the entrypoint
+WORKDIR /delib_ws
 CMD /bin/bash
 COPY docker/entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/src/.gitkeep
+++ b/src/.gitkeep
@@ -1,1 +1,0 @@
-This is where the real workshop contents will go.


### PR DESCRIPTION
Per @ct2034's comment:

> Usually in ROS repos, the packages are on the top-level. Do you think we could change the Docker workflow this way?

This PR changes the Docker bind mount to use the repo root.

It also makes a few minor changes such that the full ROS workspace is built on container entry, including the new workshop files that have just been added.

We'll probably want to keep making tweaks to this, but this should at least work now:

```
docker compose build

docker compose run base

# (in container, after build is complete)
ros2 run delib_ws_p1 run
```