### PR TITLE
Adds SkiROS2

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,3 +38,11 @@ services:
       # Allows graphical programs in the container
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
       - ${XAUTHORITY:-$HOME/.Xauthority}:/root/.Xauthority
+
+  skiros2:
+    image: roscon_delib_ws_2024:skiros2
+    depends_on:
+      - base
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.skiros2

--- a/docker/Dockerfile.skiros2
+++ b/docker/Dockerfile.skiros2
@@ -1,0 +1,19 @@
+FROM roscon_delib_ws_2024:main
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ENV WS="/delib_ws"
+WORKDIR "${WS}/src"
+
+# Clone SkiROS2
+RUN mkdir SkiROS2
+RUN git clone -b fix/ros2_jazzy_build https://github.com/RVMI/skiros2 SkiROS2/skiros2
+RUN git clone -b ros2 https://github.com/RVMI/skiros2_std_lib SkiROS2/skiros2_std_lib
+RUN touch SkiROS2/skiros2/skiros2_task/COLCON_IGNORE
+
+# Install dependencies
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get install -y python3-wrapt python3-inflection
+RUN rosdep install --from-paths . --ignore-src --rosdistro=$ROS_DISTRO -y
+
+WORKDIR "${WS}"


### PR DESCRIPTION
Added on top of Christian's branch. I am happy to rebase this PR on main once #6 is merged.

This builds on top of the common base image to:
     - Separate deliberation technology from common base
     - Avoid running the build instructions of the base image again when adding to it

@sea-bass: This should be debated. It is one out of many solutions. Since there will be a couple of PRs for the different technologies, this might be a way to separate their installation. Obviously, we want to have one single docker image at the end.