### PR TITLE
Install Groot2 inside container

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -3,21 +3,27 @@
 FROM ros:jazzy-ros-base AS roscon_delib_ws_2024
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Install dependencies
+# Install apt dependencies.
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y \
-    apt-utils python3-pip python3-tk python3-wrapt python3-inflection \
+    apt-utils curl fuse3 libfuse2 \
     libegl1 libgl1-mesa-dev libglu1-mesa-dev '^libxcb.*-dev' libx11-xcb-dev \
     libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libxrender-dev \
-    libnss3 libasound2t64 libxkbfile1
+    libnss3 libasound2t64 libxkbfile1 \
+    python3-pip python3-tk python3-wrapt python3-inflection
 
 # Create a ROS 2 workspace.
 RUN mkdir -p /delib_ws/src/
+WORKDIR /delib_ws
 
 # Install external dependencies.
-WORKDIR /delib_ws
+# Groot2 for BehaviorTree.CPP
+RUN curl -o Groot2.AppImage https://s3.us-west-1.amazonaws.com/download.behaviortree.dev/groot2_linux_installer/Groot2-v1.6.1-x86_64.AppImage && \
+    chmod a+x Groot2.AppImage && \
+    groupadd fuse && \
+    usermod -aG fuse root
 # Aggregated Python dependencies
 COPY python-requirements.txt /delib_ws
 RUN pip3 install --break-system-packages -r python-requirements.txt

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,6 +27,8 @@ services:
     # Networking and IPC for ROS 2
     network_mode: host
     ipc: host
+    # Needed to run Groot inside the container
+    privileged: true
     environment:
       # Allows graphical programs in the container
       - DISPLAY=${DISPLAY}


### PR DESCRIPTION
Added steps to install Groot2 inside the container (I just grabbed the latest version).

To test, rebuild the container.

```
docker compose build
```

Then go into the container and do:

```
docker compose run base

./Groot2.AppImage
```

![image](https://github.com/user-attachments/assets/8b01c465-ef8a-4c02-8eb4-e793711ea2e0)
