### PR TITLE
Set ROS_LOCALHOST_ONLY and do not run entrypoint twice on container startup

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -57,5 +57,4 @@ ENV NO_AT_BRIDGE 1
 # Set up the entrypoint.
 CMD /bin/bash
 COPY .docker/entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
 RUN echo "source /entrypoint.sh" >> ~/.bashrc

--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -8,7 +8,6 @@ export PYTHONWARNINGS="ignore:setup.py install is deprecated,ignore:easy_install
 
 export ROS_WS=/delib_ws
 export WORKSPACE_ROOT=$ROS_WS	# For FlexBE compatibility
-export ROS_DOMAIN_ID=0
 
 function print_ros_variables () {
         echo -e "ROS Distro: \t" $ROS_DISTRO

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
     privileged: true
     environment:
       # Ensure your ROS 2 system is only visible on the local network
-      - ROS_LOCALHOST_ONLY=1
+      - ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST
       # If you disable ROS_LOCALHOST_ONLY above, ensure you use a unique domain ID on your network
       - ROS_DOMAIN_ID=0
       # Allows graphical programs in the container

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,6 +30,10 @@ services:
     # Needed to run Groot inside the container
     privileged: true
     environment:
+      # Ensure your ROS 2 system is only visible on the local network
+      - ROS_LOCALHOST_ONLY=1
+      # If you disable ROS_LOCALHOST_ONLY above, ensure you use a unique domain ID on your network
+      - ROS_DOMAIN_ID=0
       # Allows graphical programs in the container
       - DISPLAY=${DISPLAY}
       - QT_X11_NO_MITSHM=1


### PR DESCRIPTION
As the PR description says, this will by default prevent network "fun" at the workshop.

Also added a disclaimer in the `docker-compose.yaml` file in case people disable `ROS_LOCALHOST_ONLY`, to set a unique domain ID.

Finally, snuck in a small change that prevents the entrypoint code being printed twice at container startup.