### PR TITLE
clarify start up instructions for those completely new to docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,13 @@ Verify that you can launch a simulated world and the PyRoboSim UI appears on you
 ros2 run delib_ws_worlds run
 ```
 
-*After* the initial build completes, you can open new terminals and attach to the running container from a different terminal using the command:
+*After* the initial build completes, you can open new terminals and attach to the currently running container from a different terminal using the command:
 
 ```bash
-docker compose run base bash
+docker compose exec base bash
 ```
+
+> Note: This command must be executed from the `roscon24-workshop` repository folder.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -57,28 +57,30 @@ docker compose --help
 
 ### Installation
 
-First, clone this repository and its submodules.
+First, open a terminal window and clone this repository and its submodules.
 
 ```bash
 git clone --recurse-submodules https://github.com/ros-wg-delib/roscon24-workshop.git
 ```
 
-Start the Docker container.
-Note that this will pull the Docker image and may take a few minutes.
+Change into the repository folder (`cd roscon24-workshop`) and start the Docker container.
 
 ```bash
 docker compose run base
 ```
 
-This will start the container and drop you into a bash shell.
+> Note that this will initially download the Docker image and may take a few minutes
+> for the download complete and the workspace to build.
 
-Once you're in the container, check that you can launch a simulated world and the PyRoboSim UI appears on your screen.
+After the container build finishes you will be in a bash shell.
+
+Verify that you can launch a simulated world and the PyRoboSim UI appears on your screen.
 
 ```bash
 ros2 run delib_ws_worlds run
 ```
 
-You can attach to the running container from a different console, using the command:
+You can attach to the running container from a different terminal using the command:
 
 ```bash
 docker compose run base bash
@@ -98,7 +100,7 @@ We have created handy aliases that effectively wrap around `colcon build --symli
 * `delib_build_packages_up_to <package>` - Builds all dependencies up to a specific package.
 * `delib_clean` - Cleans up the entire workspace.
 
-When you are ready to shut down the container, enter the following command:
+When you are ready to shut down the container, enter the following command from a terminal on your system:
 
 ```bash
 docker compose down --remove-orphans

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Verify that you can launch a simulated world and the PyRoboSim UI appears on you
 ros2 run delib_ws_worlds run
 ```
 
-You can attach to the running container from a different terminal using the command:
+*After* the initial build completes, you can open new terminals and attach to the running container from a different terminal using the command:
 
 ```bash
 docker compose run base bash

--- a/problems/delib_ws_worlds/worlds/world3.yaml
+++ b/problems/delib_ws_worlds/worlds/world3.yaml
@@ -200,7 +200,7 @@ locations:
       parent: kitchen
       category: storage
       pose: [-3.65, -1.5, 0.0, 1.57]
-      is_open: true
+      is_open: false
 
     - name: bin
       parent: office


### PR DESCRIPTION
Added a bit more step-by-step instructions on docker start up based on question from tester on new computer.

For `docker compose run base bash` is the `bash` necessary?

I've only done `docker compose run base` in new terminals and it seemed to work fine.
