### PR TITLE
Fix object dropping bug in P4 BT.CPP solution

### DIFF
--- a/technologies/BehaviorTree.CPP/pyrobosim_btcpp/trees/solution/problem4.xml
+++ b/technologies/BehaviorTree.CPP/pyrobosim_btcpp/trees/solution/problem4.xml
@@ -75,11 +75,14 @@
             <Navigate name="GoToTarget" target="{target}"/>
           </RetryUntilSuccessful>
         </ReactiveSequence>
-        <AlwaysFailure>
+        <Sequence>
           <RetryUntilSuccessful num_attempts="10">
             <Navigate name="GoToCharger" target="charger"/>
           </RetryUntilSuccessful>
-        </AlwaysFailure>
+          <RetryUntilSuccessful num_attempts="10">
+            <Navigate name="GoToTarget" target="{target}"/>
+          </RetryUntilSuccessful>
+        </Sequence>
       </Fallback>
     </RetryUntilSuccessful>
   </BehaviorTree>


### PR DESCRIPTION
Ditto the title.

This fixes a bug where the robot drops the item it is holding at the charger.

This occurs when:
- The robot is holding an object and is navigating to place it
- But it runs out of battery and has to go charge as part of `NavigateRobustly`

The charger navigation succeeds, causing the whole `NavigateRobustly` subtree to succeed, but then the navigation to the actual object place goal gets skipped, leading to the robot moving forward to the `PlaceRobustly` node at the charger instead.